### PR TITLE
fix: update README branding and remove non-template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With TestMu AI (Formerly LambdaTest), you can run Selenium Cucumber tests across
 
 ### Prerequisites
 
-- [Java](https://www.oracle.com/java/technologies/downloads/) and [Maven](https://maven.apache.org/) installed
+- Java and Maven installed
 - HyperExecute CLI — download the binary for your OS:
 
 | Operating System | CLI Download Link |
@@ -26,7 +26,7 @@ With TestMu AI (Formerly LambdaTest), you can run Selenium Cucumber tests across
 | Linux | https://downloads.lambdatest.com/hyperexecute/linux/hyperexecute |
 | Windows | https://downloads.lambdatest.com/hyperexecute/windows/hyperexecute.exe |
 
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 
@@ -94,7 +94,7 @@ matrix:
 ./hyperexecute --config yaml/linux/cucumber_hyperexecute_matrix_sample.yaml --force-clean-artifacts --download-artifacts
 ```
 
-Visit the [HyperExecute Dashboard](https://hyperexecute.lambdatest.com/hyperexecute) to monitor your job status and view detailed execution logs.
+Visit the HyperExecute Dashboard to monitor your job status and view detailed execution logs.
 
 ### Local testing with TestMu AI Tunnel
 


### PR DESCRIPTION
- Replace standalone LambdaTest with TestMu AI (Formerly LambdaTest) in body text\n- Remove non-template links from Prerequisites/Setup/Run tests sections